### PR TITLE
Add pre-commit to project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: 'v8.24.0' # Use the sha / tag you want to point at
+    hooks:
+      - id: eslint
+        additional_dependencies: [eslint@7.32.0, eslint-config-react-app@6.0.0]
+        files: \.[jt]sx?$

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Developers
+
+## Installing pre-commit
+Make sure to run `pre-commit install` before working on the project for the first time!


### PR DESCRIPTION
This PR adds [`pre-commit`](https://pre-commit.com/) to the project, and a README file to the home directory to remind developers to install `pre-commit` before starting to work on the project. 